### PR TITLE
cargo: update to log 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ license = "GPL-3.0"
 readme = "README.md"
 
 [dependencies]
-log = "~0.3.5"
+log = "0.4"
 


### PR DESCRIPTION
This updates the 'log' dependencies to latest version available.