### PR TITLE
cargo: add crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "w_result"
 version = "0.1.2"
 authors = ["Andrew Cann <shum@canndrew.org>"]
+repository = "https://github.com/canndrew/w_result"
+documentation = "https://docs.rs/w_result"
 description = "A result type that carries warnings"
 license = "GPL-3.0"
 readme = "README.md"


### PR DESCRIPTION
This adds some metadata to the crate (docs and repo URLs), in order
to make it easier to navigate from crates.io.

Fixes https://github.com/canndrew/w_result/issues/1